### PR TITLE
fix default option in schema builder

### DIFF
--- a/ColumnSchemaBuilder.php
+++ b/ColumnSchemaBuilder.php
@@ -19,10 +19,10 @@ class ColumnSchemaBuilder extends BaseColumnSchemaBuilder
     {
         switch ($this->getTypeCategory()) {
             case self::CATEGORY_NUMERIC:
-                $format = '{unsigned}{type}';
+                $format = '{unsigned}{type}{default}';
                 break;
             default:
-                $format = '{type}';
+                $format = '{type}{default}';
         }
 
         return $this->buildCompleteString($format);

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -51,9 +51,13 @@ class QueryBuilder extends BaseQueryBuilder
 
         if (isset($this->typeMap[$type])) {
             return $this->typeMap[$type];
+        } elseif (preg_match('/^(\w+)\s+/', $type, $matches)) {
+            if (isset($this->typeMap[$matches[1]])) {
+                return preg_replace('/^\w+/', $this->typeMap[$matches[1]], $type);
+            }
         } elseif (preg_match('/^U(\w+)/', $type, $matches)) {
             if (isset($this->typeMap[$matches[1]])) {
-                return 'U'. $this->typeMap[$matches[1]];
+                return 'U' . $this->typeMap[$matches[1]];
             }
         }
 


### PR DESCRIPTION
This fix allows setting default expression in `ColumnSchemaBuilder`, e.g:
```php
...
'created_at' => $this->dateTime()->defaultExpression('now()'), 
...
```