### PR TITLE
fix using clickhouse component in module

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -23,6 +23,18 @@ class ActiveQuery extends Query implements ActiveQueryInterface
         $this->modelClass = $modelClass;
         parent::__construct($config);
     }
+    
+    /**
+    * Creates a DB command that can be used to execute this query.
+    * @param Connection|null $db the DB connection used to create the DB command.
+    * If `null`, the DB connection returned by [[modelClass]] will be used.
+    * @return Command the created DB command instance.
+    */
+    public function createCommand($db = null)
+    {
+        $modelClass = $this->modelClass;
+        return parent::createCommand($db ? $db : $modelClass::getDb());
+    }
 
     /**
      * Returns the number of records.

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -191,5 +191,15 @@ class QueryBuilder extends BaseQueryBuilder
 
         return ltrim($sql);
     }
-
+    
+    /**
+     * Creates a SELECT EXISTS() SQL statement.
+     * @param string $rawSql the subquery in a raw form to select from.
+     * @return string the SELECT EXISTS() SQL statement.
+     * @since 2.0.8
+    */
+    public function selectExists($rawSql)
+    {
+        return 'SELECT count(*) FROM (' . $rawSql . ')';
+    }
 }


### PR DESCRIPTION
When we have clickhouse activerecord in module, we've change ActiveRecord::getDb method. Without this fix, Yii try to use global clickhouse component (\Yii::$app->get('clickhouse'))