### PR TITLE
Query.php patch

### DIFF
--- a/Query.php
+++ b/Query.php
@@ -191,11 +191,7 @@ class Query extends BaseQuery
     }
     
     /**
-     * Queries a scalar value by setting [[select]] first.
-     * Restores the value of select to make this query reusable.
-     * @param string|Expression $selectExpression
-     * @param Connection|null $db
-     * @return bool|string
+     * @inheritdoc
      */
     protected function queryScalar($selectExpression, $db)
     {
@@ -203,31 +199,33 @@ class Query extends BaseQuery
             return null;
         }
 
-        $select = $this->select;
-        $limit = $this->limit;
-        $offset = $this->offset;
-
-        $this->select = [$selectExpression];
-        $this->limit = null;
-        $this->offset = null;
-        $command = $this->createCommand($db);
-
-        $this->select = $select;
-        $this->limit = $limit;
-        $this->offset = $offset;
-
         if (
             !$this->distinct
             && empty($this->groupBy)
             && empty($this->having)
             && empty($this->union)
-            && empty($this->orderBy)
         ) {
+            $select = $this->select;
+            $order = $this->orderBy;
+            $limit = $this->limit;
+            $offset = $this->offset;
+
+            $this->select = [$selectExpression];
+            $this->orderBy = null;
+            $this->limit = null;
+            $this->offset = null;
+            $command = $this->createCommand($db);
+
+            $this->select = $select;
+            $this->orderBy = $order;
+            $this->limit = $limit;
+            $this->offset = $offset;
+
             return $command->queryScalar();
         } else {
             return (new static)->select([$selectExpression])
                 ->from(['c' => $this])
-                ->createCommand($command->db)
+                ->createCommand($db)
                 ->queryScalar();
         }
     }


### PR DESCRIPTION
Need to reload parent queryScalar() method in case it refer on yii/db/Query object in last return statement instead of static instance.  It leads to errors in createCommand next call because you also reload build() method in your QueryBuilder class that has own specific method calls like buildSample(), buildPreWhere(), buildWithTotals().