### PR TITLE
swap buildWithTotals and buildHaving methods, because WITH TOTALS needs to be before HAVING

### DIFF
--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -74,8 +74,8 @@ class QueryBuilder extends BaseQueryBuilder
             $this->buildPreWhere($query->preWhere, $params),
             $this->buildWhere($query->where, $params),
             $this->buildGroupBy($query->groupBy),
-            $this->buildHaving($query->having, $params),
             $this->buildWithTotals($query->hasWithTotals()),
+            $this->buildHaving($query->having, $params),
         ];
 
         $sql = implode($this->separator, array_filter($clauses));


### PR DESCRIPTION
https://clickhouse.yandex/docs/en/query_language/queries.html#select

SELECT [DISTINCT] expr_list
    [FROM [db.]table | (subquery) | table_function] [FINAL]
    [SAMPLE sample_coeff]
    [ARRAY JOIN ...]
    [GLOBAL] ANY|ALL INNER|LEFT JOIN (subquery)|table USING columns_list
    [PREWHERE expr]
    [WHERE expr]
    [GROUP BY expr_list] [WITH TOTALS]
    [HAVING expr]
    [ORDER BY expr_list]
    [LIMIT [n, ]m]
    [UNION ALL ...]
    [INTO OUTFILE filename]
    [FORMAT format]