### PR TITLE
Fix MigrationSchemaCommand for PHP 7.2

### DIFF
--- a/console/MigrationSchemaCommand.php
+++ b/console/MigrationSchemaCommand.php
@@ -7,11 +7,11 @@
  */
 namespace kak\clickhouse\console;
 use kak\clickhouse\Schema;
-use yii\base\Object;
+use yii\base\BaseObject;
 use Yii;
 
 
-class MigrationSchemaCommand extends Object
+class MigrationSchemaCommand extends BaseObject
 {
     const RESULT_TYPE_SQL = 1;
     const RESULT_TYPE_MIGRATION = 2;


### PR DESCRIPTION
Fix MigrationSchemaCommand for **PHP 7.2** and **Yii 2.0.13**.
Replacing the reserved class name **Object** on the **BasicObject**.
**Attention!** this works only for Yii 2.0.13.