### PR TITLE
fix add column statement

### DIFF
--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -250,4 +250,14 @@ class QueryBuilder extends \yii\db\QueryBuilder
     {
         return 'SELECT count(*) FROM (' . $rawSql . ')';
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function addColumn($table, $column, $type)
+    {
+        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
+            . ' ADD COLUMN ' . $this->db->quoteColumnName($column) . ' '
+            . $this->getColumnType($type);
+    }
 }


### PR DESCRIPTION
Не работают миграции: генерируется неверный sql.

```
$this->addColumn('table', 'column', 'String');
```
этот PR должен решить эту проблему.