### PR TITLE
migration char fix

### DIFF
--- a/console/MigrationDataCommand.php
+++ b/console/MigrationDataCommand.php
@@ -95,7 +95,7 @@ class MigrationDataCommand extends BaseObject
             } else if (isset($this->_schema->columns[$key])) {
                 $val = $this->castTypeValue($key, $item);
             }
-            $out[$key] = $val;
+            $out[$key] = str_replace("'", '', $val);
         }
 
         if ($this->format == self::FORMAT_JSON_EACH_ROW) {


### PR DESCRIPTION
Формируется некорректный JSON, например вот такой:
"created_datetime":"\'2019-03-15 19:41:14\'",
внутри значения лишняя кавычка, фикс убирает ее и загрузка успешно отрабатывает