### PR TITLE
Fixed delete syntax in QueryBuilder

### DIFF
--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -48,7 +48,16 @@ class QueryBuilder extends \yii\db\QueryBuilder
         }
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function delete($table, $condition, &$params)
+    {
+        $sql = 'ALTER TABLE ' . $this->db->quoteTableName($table). ' DELETE';
+        $where = $this->buildWhere($condition, $params);
 
+        return $where === '' ? $sql : $sql . ' ' . $where;
+    }
 
     /**
      * Generates a SELECT SQL statement from a [[Query]] object.


### PR DESCRIPTION
Delete function wasn't redefined in \kak\clickhouse\QueryBuilder

This lead to wrongly created SQL - "_DELETE FROM tableName_" instead of "_ALTER TABLE tableName DELETE..._"

Added the function.