### PR TITLE
load TableSchema when table name contain dot

### DIFF
--- a/Schema.php
+++ b/Schema.php
@@ -161,10 +161,18 @@ class Schema extends \yii\db\Schema
      */
     protected function loadTableSchema($name)
     {
+        $database = $this->db->database === null ? 'default' : $this->db->database;
+
+        if (stripos($name,'.')) {
+            $schemaData = explode('.',$name);
+            $database = $schemaData[0];
+            $name = $schemaData[1];
+        }
+
         $sql = 'SELECT * FROM system.columns WHERE `table`=:name and `database`=:database FORMAT JSON';
         $result = $this->db->createCommand($sql, [
             ':name' => $name,
-            ':database' => $this->db->database === null ? 'default' : $this->db->database
+            ':database' => $database,
         ])->queryAll();
 
         if ($result && isset($result[0])) {


### PR DESCRIPTION
RU:
В случае, если tableName в модели указана как [schema].[tableName] не удается получить модель через методы $model->find()->one(), данные отдаются сервером Clickhouse, но при заполнении модели не находится схема таблицы, т.к. имя ищем в default схеме.
При это, если указать $model->find()->asArray()->one(), данные отдаются, т.к. модель не заполняется.

ENG:
In case tableName in models is indicated as [schema]. [TableName] can’t get the model using the methods $model->find()->one(), data is sent from the Clickhouse server, but when populated model, does not find schema, because we are looking name in the default schema.
In this case, if you specify $model->find()->asArray()->one(), the data is given, because the model is not populated.